### PR TITLE
Fix crash with unicode status updates

### DIFF
--- a/twitter/oauth.py
+++ b/twitter/oauth.py
@@ -87,11 +87,11 @@ def urlencode_noplus(query):
     encoded_bits = []
     for n, v in query:
         # and do unicode here while we are at it...
-        if isinstance(n, str):
+        if isinstance(n, basestring):
             n = n.encode('utf-8')
         else:
             n = str(n)
-        if isinstance(v, str):
+        if isinstance(v, basestring):
             v = v.encode('utf-8')
         else:
             v = str(v)


### PR DESCRIPTION
The API crashes when posting a status update with unicode characters. This patch uses basestring instead of str to check if the value should be UTF-8-encoded.
