### PR TITLE
Fix error in WrappedTwitterResponse, headers isn't transmited to object

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,6 +1,7 @@
 # encoding: utf8
 
 from random import choice
+import time
 
 from twitter import Twitter, NoAuth, OAuth, read_token_file
 from twitter.cmdline import CONSUMER_KEY, CONSUMER_SECRET
@@ -30,9 +31,11 @@ def test_API_get_some_public_tweets():
 def test_API_set_tweet():
     random_tweet = "A random tweet " + get_random_str()
     twitter.statuses.update(status=random_tweet)
-
+    time.sleep(2)
     recent = twitter.statuses.user_timeline()
     assert recent
+    assert isinstance(recent.rate_limit_remaining, int)
+    assert isinstance(recent.rate_limit_reset, int)
     assert random_tweet == recent[0]['text']
 
 

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -79,7 +79,11 @@ def wrap_response(response, headers):
     class WrappedTwitterResponse(response_typ, TwitterResponse):
         __doc__ = TwitterResponse.__doc__
 
-    return WrappedTwitterResponse(response)
+        def __init__(self, response, headers):
+            response_typ.__init__(self, response)
+            TwitterResponse.__init__(self, headers)
+
+    return WrappedTwitterResponse(response, headers)
 
 
 


### PR DESCRIPTION
Hi,

this is a patch to fix mistake in api.wrap_response, before this fix, we can't access to "rate_limit_remaining" and "rate_limit_reset" properties in "WrappedTwitterResponse" class

Regards,
Stephane
