### PR TITLE
Add gzip compression to http requests

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -5,10 +5,16 @@ except ImportError:
     import urllib2 as urllib_request
     import urllib2 as urllib_error
 
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from StringIO import StringIO
+
 from twitter.twitter_globals import POST_ACTIONS
 from twitter.auth import NoAuth
 
 import re
+import gzip
 
 try:
     import json
@@ -153,7 +159,7 @@ class TwitterCall(object):
         uriBase = "http%s://%s/%s%s%s" %(
                     secure_str, self.domain, uri, dot, self.format)
 
-        headers = {}
+        headers = {'Accept-Encoding': 'gzip'}
         if self.auth:
             headers.update(self.auth.generate_headers())
             arg_data = self.auth.encode_params(uriBase, method, kwargs)
@@ -169,12 +175,20 @@ class TwitterCall(object):
     def _handle_response(self, req, uri, arg_data):
         try:
             handle = urllib_request.urlopen(req)
+            if handle.info().get('Content-Encoding') == 'gzip':
+                # Handle gzip decompression
+                buf = StringIO(handle.read())
+                f = gzip.GzipFile(fileobj=buf)
+                data = f.read()
+            else:
+                data = handle.read()
+
             if "json" == self.format:
-                res = json.loads(handle.read().decode('utf8'))
+                res = json.loads(data.decode('utf8'))
                 return wrap_response(res, handle.headers)
             else:
                 return wrap_response(
-                    handle.read().decode('utf8'), handle.headers)
+                    data.decode('utf8'), handle.headers)
         except urllib_error.HTTPError as e:
             if (e.code == 304):
                 return []


### PR DESCRIPTION
Because Tweeter API is very verbose, I Added gzip compression support to http requests.

On a response with 50 tweets, the response size was divided by 10 and response time by 7.
