### PR TITLE
Bug fix for profile image API

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -169,6 +169,8 @@ class TwitterCall(object):
     def _handle_response(self, req, uri, arg_data):
         try:
             handle = urllib_request.urlopen(req)
+            if handle.headers['Content-Type'] in ['image/jpeg', 'image/png']:
+                return handle
             if "json" == self.format:
                 res = json.loads(handle.read().decode('utf8'))
                 return wrap_response(res, handle.headers)


### PR DESCRIPTION
This resource does not return JSON or XML, but instead returns a 302 redirect to the actual image resource.

Without proper handling, this result :

```
     15 def decode(input, errors='strict'):
---> 16     return codecs.utf_8_decode(input, errors, True)
     17 
     18 class IncrementalEncoder(codecs.IncrementalEncoder):

UnicodeDecodeError: 'utf8' codec can't decode byte 0xff in position 0: invalid start byte
```
