### PR TITLE
running cmdline on Python 3.2.3

### DIFF
--- a/twitter/cmdline.py
+++ b/twitter/cmdline.py
@@ -66,7 +66,7 @@ from __future__ import print_function
 
 try:
     input = __builtins__['raw_input']
-except AttributeError:
+except (AttributeError, KeyError):
     pass
 
 


### PR DESCRIPTION
got an uncaught "KeyError" when running `twitter --help` for the first time, on python 3.2.3.  Turned out that `__builtins__['raw_input']` throws a KeyError, not an AttributeError (at least on this platform), so the exception was not caught.
