### PR TITLE
archiver downloads duplicate tweets

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -18,7 +18,7 @@ def test_find_links():
     assert find_links("http://abc") == ("%s", ["http://abc"])
     assert find_links("t http://abc") == ("t %s", ["http://abc"])
     assert find_links("http://abc t") == ("%s t", ["http://abc"])
-    assert find_links("1 http://a 2 http://b 3") == ("1 %s 2 %s 3", 
+    assert find_links("1 http://a 2 http://b 3") == ("1 %s 2 %s 3",
         ["http://a", "http://b"])
     assert find_links("%") == ("%%", [])
     assert find_links("(http://abc)") == ("(%s)", ["http://abc"])
@@ -30,11 +30,11 @@ Response = namedtuple('Response', 'path code headers')
 def start_server(*resp):
     """HTTP server replying with the given responses to the expected
     requests."""
-    def url(port, path): 
+    def url(port, path):
         return 'http://%s:%s%s' % (socket.gethostname(), port, path)
-    
+
     responses = list(reversed(resp))
-    
+
     class MyHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         def do_HEAD(self):
             response = responses.pop()
@@ -43,7 +43,7 @@ def start_server(*resp):
             for header, value in list(response.headers.items()):
                 self.send_header(header, value)
             self.end_headers()
-            
+
     httpd = SocketServer.TCPServer(("", 0), MyHandler)
     t = threading.Thread(target=httpd.serve_forever)
     t.setDaemon(True)
@@ -51,7 +51,7 @@ def start_server(*resp):
     port = httpd.server_address[1]
     yield functools.partial(url, port)
     httpd.shutdown()
-    
+
 def test_follow_redirects_direct_link():
     link = "/resource"
     with start_server(Response(link, 200, {})) as url:
@@ -61,10 +61,10 @@ def test_follow_redirects_redirected_link():
     redirected = "/redirected"
     link = "/resource"
     with start_server(
-        Response(link, 301, {"Location": redirected}), 
+        Response(link, 301, {"Location": redirected}),
         Response(redirected, 200, {})) as url:
         assert url(redirected) == follow_redirects(url(link))
-        
+
 def test_follow_redirects_unavailable():
     link = "/resource"
     with start_server(Response(link, 404, {})) as url:
@@ -74,7 +74,7 @@ def test_follow_redirects_link_to_last_available():
     unavailable = "/unavailable"
     link = "/resource"
     with start_server(
-        Response(link, 301, {"Location": unavailable}), 
+        Response(link, 301, {"Location": unavailable}),
         Response(unavailable, 404, {})) as url:
         assert url(unavailable) == follow_redirects(url(link))
 
@@ -82,7 +82,7 @@ def test_follow_redirects_link_to_last_available():
 def test_follow_redirects_no_where():
     link = "http://links.nowhere/"
     assert link == follow_redirects(link)
-    
+
 def test_follow_redirects_link_to_nowhere():
     unavailable = "http://links.nowhere/"
     link = "/resource"
@@ -101,7 +101,7 @@ def test_follow_redirects_filtered_by_site_after_redirect():
     redirected = "/redirected"
     filtered = "http://dont-follow/"
     with start_server(
-        Response(link, 301, {"Location": redirected}), 
+        Response(link, 301, {"Location": redirected}),
         Response(redirected, 301, {"Location": filtered})) as url:
         hosts = [socket.gethostname()]
         assert filtered == follow_redirects(url(link), hosts)
@@ -110,7 +110,7 @@ def test_follow_redirects_filtered_by_site_allowed():
     redirected = "/redirected"
     link = "/resource"
     with start_server(
-        Response(link, 301, {"Location": redirected}), 
+        Response(link, 301, {"Location": redirected}),
         Response(redirected, 200, {})) as url:
         hosts = [socket.gethostname()]
         assert url(redirected) == follow_redirects(url(link), hosts)
@@ -119,7 +119,7 @@ def test_expand_line():
     redirected = "/redirected"
     link = "/resource"
     with start_server(
-        Response(link, 301, {"Location": redirected}), 
+        Response(link, 301, {"Location": redirected}),
         Response(redirected, 200, {})) as url:
         fmt = "before %s after"
         line = fmt % url(link)

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -167,7 +167,7 @@ class TwitterCall(object):
         _id = kwargs.pop('_id', None)
         if _id:
             kwargs['id'] = _id
-        
+
         # If an _timeout is specified in kwargs, use it
         _timeout = kwargs.pop('_timeout', None)
 
@@ -262,7 +262,7 @@ class Twitter(TwitterCall):
         # Note how the magic `_` method can be used to insert data
         # into the middle of a call. You can also use replacement:
         t.user.list.members(user="tamtar", list="things-that-are-rad")
-        
+
         # An *optional* `_timeout` parameter can also be used for API
         # calls which take much more time than normal or twitter stops
         # responding for some reasone

--- a/twitter/archiver.py
+++ b/twitter/archiver.py
@@ -309,7 +309,7 @@ def main(args=sys.argv[1:]):
         format_text = functools.partial(expand_format_text, hosts)
     else:
         format_text = direct_format_text
-    
+
     # save own timeline or mentions (the user used in OAuth)
     if options['timeline'] or options['mentions']:
         if isinstance(auth, NoAuth):

--- a/twitter/oauth.py
+++ b/twitter/oauth.py
@@ -130,5 +130,5 @@ def urlencode_noplus(query):
             new_query.append((k, v))
         query = new_query
         return urlencode(query).replace("+", "%20")
-        
+
     return urlencode(query, safe='~').replace("+", "%20")

--- a/twitter/util.py
+++ b/twitter/util.py
@@ -88,15 +88,15 @@ def find_links(line):
     l = line.replace("%", "%%")
     regex = "(https?://[^ )]+)"
     return (
-        re.sub(regex, "%s", l), 
+        re.sub(regex, "%s", l),
         [m.group(1) for m in re.finditer(regex, l)])
-    
+
 def follow_redirects(link, sites= None):
     """Follow directs for the link as long as the redirects are on the given
     sites and return the resolved link."""
     def follow(url):
         return sites == None or urlparse.urlparse(url).hostname in sites
-                
+
     class RedirectHandler(urllib2.HTTPRedirectHandler):
         def __init__(self):
             self.last_url = None
@@ -108,7 +108,7 @@ def follow_redirects(link, sites= None):
                 self, req, fp, code, msg, hdrs, newurl)
             r.get_method = lambda : 'HEAD'
             return r
-            
+
     if not follow(link):
         return link
     redirect_handler = RedirectHandler()
@@ -133,4 +133,4 @@ def parse_host_list(list_of_hosts):
     p = set(
         m.group(1) for m in re.finditer("\s*([^,\s]+)\s*,?\s*", list_of_hosts))
     return p
-    
+


### PR DESCRIPTION
The log to the screen shows the downloaded tweets come in sizes 200,199,199.  Example;

```
Archiving nprnews tweets in ./nprnews
Browsing nprnews statuses, new tweets: 200
Browsing nprnews statuses, new tweets: 199
Browsing nprnews statuses, new tweets: 199
```

So I compared the tweet ID keys and found duplicate tweets. 
