### PR TITLE
Being safe looking for content-encoding header

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -48,7 +48,7 @@ class TwitterHTTPError(TwitterError):
             # can't read the error text
             # let's try some of it
             data = e.partial
-        if self.e.headers['Content-Encoding'] == 'gzip':
+        if self.e.headers.get('Content-Encoding') == 'gzip':
             buf = StringIO(data)
             f = gzip.GzipFile(fileobj=buf)
             self.response_data = f.read()


### PR DESCRIPTION
I managed to bump into a situation with stream.twitter.com where the content encoding header was not in the headers ... so I am making the check more robust to handle the case where the header is not there.

@sixohsix can you consider merging this in before the micro version bump.
