### PR TITLE
Make the repo git-submodule friendly

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,5 @@
 # this file is here to make the importation of the project as a git-submodule possible
 # command example: git submodule add git://github.com/sixohsix/twitter.git twitter
 
-import twitterfrom .twitter import *
+from .twitter import Twitter, TwitterStream, TwitterResponse, TwitterError, TwitterHTTPError, NoAuth, OAuth, \
+    UserPassAuth, read_token_file, write_token_file, oauth_dance


### PR DESCRIPTION
Added an empty `__init__.py` so that the repo can be imported as a git-submodule in another projet like so:

``` bash
git submodule add git://github.com/sixohsix/twitter.git twitter
```

so we can use: 

``` python
import twitter
```

in the project where it was imported without the need to install it system-wide on the machine (when it's used for developpement purpose only)
