### PR TITLE
use relative imports in api.py for twitter_globals and auth

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -10,8 +10,8 @@ try:
 except ImportError:
     from io import BytesIO as StringIO
 
-from twitter.twitter_globals import POST_ACTIONS
-from twitter.auth import NoAuth
+from .twitter_globals import POST_ACTIONS
+from .auth import NoAuth
 
 import re
 import gzip


### PR DESCRIPTION
changed

``` python
from twitter.twitter_globals import POST_ACTIONS
from twitter.auth import NoAuth
```

to:

``` python
from .twitter_globals import POST_ACTIONS
from .auth import NoAuth
```

in `twitter/api.py` to match import usage made in `twitter/*.py`
