### PR TITLE
Fix twitter stream under python 3

### DIFF
--- a/twitter/stream.py
+++ b/twitter/stream.py
@@ -8,6 +8,7 @@ except ImportError:
 import json
 from ssl import SSLError
 import socket
+import sys
 
 from .api import TwitterCall, wrap_response
 
@@ -20,7 +21,10 @@ class TwitterJSONIter(object):
         self.block = block
 
     def __iter__(self):
-        sock = self.handle.fp._sock.fp._sock
+        if sys.version_info >= (3, 0):
+            sock = self.handle.fp.raw._sock
+        else:
+            sock = self.handle.fp._sock.fp._sock
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         if not self.block:
             sock.setblocking(False)


### PR DESCRIPTION
This fixes the "AttributeError: '_io.BufferedReader' object has no attribute '_sock'" error when trying to create a twitter stream with python3.

There are two issues (#70 and #108) that are fixed with this commit.

I have written a twitter script in python 3 with your twitter lib so I would be really glad if you can merge this and then create a new point release of the lib.

That way I can release the script without having to tell the users to manually patch the twitter lib.

I'm sorry if you've already read my reply to #108. But I would really like this to get merged and released ASAP.
