### PR TITLE
Import TwitterHTTPError for stream module

### DIFF
--- a/twitter/stream.py
+++ b/twitter/stream.py
@@ -10,7 +10,7 @@ from ssl import SSLError
 import socket
 import sys
 
-from .api import TwitterCall, wrap_response
+from .api import TwitterCall, wrap_response, TwitterHTTPError
 
 class TwitterJSONIter(object):
 


### PR DESCRIPTION
The TwitterJSONIter raises TwitterHTTPError on HTTPError, but it is never imported into the module.
