### PR TITLE
Use POST with Streaming API

### DIFF
--- a/twitter/twitter_globals.py
+++ b/twitter/twitter_globals.py
@@ -28,6 +28,9 @@ POST_ACTIONS = [
     # Block Methods, Friendship Methods, Favorite Methods
     'create', 'create_all',
 
+    # Streaming Methods
+    'filter', 'sample', 'firehose', 'user', 'site',
+
     # OAuth Methods
     'token',
 ]


### PR DESCRIPTION
Twitter recommends to use preferably POST for the Streaming methods so the 5 specific streaming methods should be listed here.
