### PR TITLE
POST for "statuses/filter" in Streaming API

### DIFF
--- a/twitter/twitter_globals.py
+++ b/twitter/twitter_globals.py
@@ -28,6 +28,9 @@ POST_ACTIONS = [
     # Block Methods, Friendship Methods, Favorite Methods
     'create', 'create_all',
 
+    # Users Methods
+    'lookup',
+
     # Semantic Methods
     'filter',
 


### PR DESCRIPTION
Twitter recommends to use preferably POST for the filter method in the Streaming API https://dev.twitter.com/docs/api/1.1/post/statuses/filter
So it should be listed here
