### PR TITLE
Used named argument to avoid TypeError

### DIFF
--- a/README
+++ b/README
@@ -283,7 +283,7 @@ twitter = Twitter(auth=OAuth(
     oauth_token, oauth_secret, CONSUMER_KEY, CONSUMER_SECRET))
 
 # Now work with Twitter
-twitter.statuses.update('Hello, world!')
+twitter.statuses.update(status='Hello, world!')
 ```
 
 


### PR DESCRIPTION
Named argument is needed to avoid: `TypeError: __call__() takes exactly 1 argument (2 given)`
