### PR TITLE
use relative import in oauth2.py for auth

### DIFF
--- a/twitter/oauth2.py
+++ b/twitter/oauth2.py
@@ -28,7 +28,7 @@ except ImportError:
     from urllib import quote, urlencode
 
 from base64 import b64encode
-from twitter.auth import Auth
+from .auth import Auth
 
 
 class OAuth2(Auth):


### PR DESCRIPTION
Changed: 

``` py
from twitter.auth import Auth
```

To:

``` py
from .auth import Auth
```

in `twitter/oauth2.py` to match import usage made in `twitter/*.py`
