### PR TITLE
Exceptions thrown by library are not correctly initialized and therefore are not informative enough

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -59,6 +59,7 @@ class TwitterHTTPError(TwitterError):
             self.response_data = f.read()
         else:
             self.response_data = data
+        super(TwitterHTTPError, self).__init__(str(self))
 
     def __str__(self):
         fmt = ("." + self.format) if self.format else ""


### PR DESCRIPTION
Makes this really bad when running tasks in celery, for example.
