### PR TITLE
Fix CPU and userstream issues with non blocking streaming modes (follow-up #205)

### DIFF
--- a/twitter/stream.py
+++ b/twitter/stream.py
@@ -105,7 +105,7 @@ class TwitterJSONIter(object):
 
     def __iter__(self):
         actually_block = self.block and not self.timeout
-        sock_timeout = min(self.timeout or 1000000, self.heartbeat_timeout) if actually_block else None
+        sock_timeout = min(self.timeout or 1000000, self.heartbeat_timeout)
         sock = self.handle.fp.raw._sock if PY_3_OR_HIGHER else self.handle.fp._sock.fp._sock
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         sock.setblocking(actually_block)
@@ -135,10 +135,9 @@ class TwitterJSONIter(object):
                 yield Timeout
 
             try:
-                if sock_timeout:
-                    ready_to_read = select.select([sock], [], [], sock_timeout)[0]
-                    if not ready_to_read:
-                        continue
+                ready_to_read = select.select([sock], [], [], sock_timeout)[0]
+                if not ready_to_read:
+                    continue
                 received = recv_chunk(reader)
                 buf += received.decode('utf-8')
                 if received:


### PR DESCRIPTION
The problem seems to come from incomplete reads being caught as SSLErrors during the process of recv_chunk. This results in size being read already read and not available anymore for further reading. I fixed it by moving the catching to the level of the atomic read.

I took the occasion and tried to fix the CPU issue I discussed in #205 as well. It seems to me that the blocking mode is already handled by the sock and should not reflect on the part where we check for incoming data. This fixes the CPU issue while still having timeouts work, but I'm not 100% sure this doesn't make it blocking during some parts. Happy to divide the PR if you prefer.
