### PR TITLE
Support pickling at the risk of breaking some stuff

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -2,8 +2,11 @@
 
 from random import choice
 import time
+import pickle
+import json
 
 from twitter import Twitter, NoAuth, OAuth, read_token_file, TwitterHTTPError
+from twitter.api import TwitterDictResponse, TwitterListResponse
 from twitter.cmdline import CONSUMER_KEY, CONSUMER_SECRET
 
 noauth = NoAuth()
@@ -51,6 +54,7 @@ def test_get_trends_3():
     # Of course they broke it all again in 1.1...
     assert twitter11.trends.place(_id=1)
 
+
 def test_TwitterHTTPError_raised_for_invalid_oauth():
     test_passed = False
     try:
@@ -59,3 +63,31 @@ def test_TwitterHTTPError_raised_for_invalid_oauth():
         # this is the error we are looking for :)
         test_passed = True
     assert test_passed
+
+
+def test_picklability():
+    res = TwitterDictResponse({'a': 'b'})
+    p = pickle.dumps(res)
+    res2 = pickle.loads(p)
+    assert res == res2
+    assert res2['a'] == 'b'
+
+    res = TwitterListResponse([1, 2, 3])
+    p = pickle.dumps(res)
+    res2 = pickle.loads(p)
+    assert res == res2
+    assert res2[2] == 3
+
+
+def test_jsonifability():
+    res = TwitterDictResponse({'a': 'b'})
+    p = json.dumps(res)
+    res2 = json.loads(p)
+    assert res == res2
+    assert res2['a'] == 'b'
+
+    res = TwitterListResponse([1, 2, 3])
+    p = json.dumps(res)
+    res2 = json.loads(p)
+    assert res == res2
+    assert res2[2] == 3

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -79,8 +79,6 @@ class TwitterResponse(object):
     httplib.HTTPHeaders instance. You can do
     `response.headers.get('h')` to retrieve a header.
     """
-    def __init__(self, headers):
-        self.headers = headers
 
     @property
     def rate_limit_remaining(self):
@@ -104,25 +102,25 @@ class TwitterResponse(object):
         return int(self.headers.get('X-Rate-Limit-Reset', "0"))
 
 
+class TwitterDictResponse(dict, TwitterResponse):
+    pass
+
+
+class TwitterListResponse(list, TwitterResponse):
+    pass
+
+
 def wrap_response(response, headers):
     response_typ = type(response)
-    if response_typ is bool:
-        # HURF DURF MY NAME IS PYTHON AND I CAN'T SUBCLASS bool.
-        response_typ = int
-    elif response_typ is str:
-        return response
-
-    class WrappedTwitterResponse(response_typ, TwitterResponse):
-        __doc__ = TwitterResponse.__doc__
-
-        def __init__(self, response, headers):
-            response_typ.__init__(self, response)
-            TwitterResponse.__init__(self, headers)
-        def __new__(cls, response, headers):
-            return response_typ.__new__(cls, response)
-
-    return WrappedTwitterResponse(response, headers)
-
+    if response_typ is dict:
+        res = TwitterDictResponse(response)
+        res.headers = headers
+    elif response_typ is list:
+        res = TwitterListResponse(response)
+        res.headers = headers
+    else:
+        res = response
+    return res
 
 
 class TwitterCall(object):


### PR DESCRIPTION
- support pickling of responses (#82)
- silence Python 2.6 warning (#179)
- this makes rate-limit headers unavailable on boolean or string responses. I'm not sure if that's a problem.
