### PR TITLE
u"" is a SyntaxError in py3.2

### DIFF
--- a/twitter/stream.py
+++ b/twitter/stream.py
@@ -81,7 +81,10 @@ class HttpChunkDecoder(object):
 class JsonDecoder(object):
 
     def __init__(self):
-        self.buf = u""
+        if PY_3_OR_HIGHER:
+            self.buf = ""
+        else:
+            self.buf = u""
         self.raw_decode = json.JSONDecoder().raw_decode
 
     def decode(self, data):


### PR DESCRIPTION
should be safe to just use the stdlib str for py3+
