### PR TITLE
twitter-archiver: Option file path fixed for Windows

### DIFF
--- a/twitter/archiver.py
+++ b/twitter/archiver.py
@@ -328,8 +328,11 @@ def main(args=sys.argv[1:]):
 
     # authenticate using OAuth, asking for token if necessary
     if options['oauth']:
-        oauth_filename = (os.getenv("HOME", "") + os.sep
-                          + ".twitter-archiver_oauth")
+        oauth_filename = (os.environ.get('HOME', 
+                          os.environ.get('USERPROFILE', '')) 
+                          + os.sep
+                          + '.twitter-archiver_oauth')
+        
         if not os.path.exists(oauth_filename):
             oauth_dance("Twitter-Archiver", CONSUMER_KEY, CONSUMER_SECRET,
                         oauth_filename)


### PR DESCRIPTION
Hi, similar to the fix for issue https://github.com/sixohsix/twitter/issues/60, I have adapted the file path for twitter-archiver to work in Windows. Tested under Ubuntu 12.04 and Windows 7, Python 2.7.
