### PR TITLE
Mention in README about 100% CPU usage with non-blocking mode.

### DIFF
--- a/README
+++ b/README
@@ -237,7 +237,8 @@ waiting for tweets.
 The `block` parameter sets the stream to be fully non-blocking. In
 this mode, the iterator always yields immediately. It returns
 stream data, or `None`. Note that `timeout` supercedes this
-argument, so it should also be set `None` to use this mode.
+argument, so it should also be set `None` to use this mode, 
+and non-blocking can potentially lead to 100% CPU usage.
 
 Twitter Response Objects
 ------------------------


### PR DESCRIPTION
Hello.

Firstly thanks for making this awesome library. I used PTT to create a CLI Twitter client here:
[https://github.com/DTVD/rainbowstream](https://github.com/DTVD/rainbowstream)

In my development, someone noticed me an issue about 100% CPU usage while using non-blocking mode of PTT. This cause by the iterator yielding immediately every time.

I think it worth to mention in README file.
