### PR TITLE
[RFC] Handle API rate limiting

### DIFF
--- a/README
+++ b/README
@@ -146,6 +146,7 @@ Retrying after reaching the API rate limit
 
 Simply create the `Twitter` instance with the argument `retry=True`, then the
 HTTP error codes 429, 502, 503 and 504 will cause a retry of the last request.
+If retry is an integer, it defines the number of retries attempted.
 
 
 Using the data returned


### PR DESCRIPTION
I think this should be handled by the library.

I'm not sure about how to notify the user about the waits, but since these are all command line tools, I think using stderr is appropriate.
