### PR TITLE
Fix reference to Twitter API doc URL

### DIFF
--- a/README
+++ b/README
@@ -74,7 +74,7 @@ is decoded python objects (lists and dicts).
 
 The Twitter API is documented at:
 
-**[http://dev.twitter.com/doc](http://dev.twitter.com/doc)**
+**[https://dev.twitter.com/overview/documentation](https://dev.twitter.com/overview/documentation)**
 
 Examples:
 ```python


### PR DESCRIPTION
Closes #258.

Use more general https://dev.twitter.com/overview/documentation rather than https://dev.twitter.com/rest/public.

[CI skip]
