### PR TITLE
Use Six's method to determine when running under Python 3.

### DIFF
--- a/twitter/oauth.py
+++ b/twitter/oauth.py
@@ -41,17 +41,18 @@ code it all goes like this::
 
 from __future__ import print_function
 
-from time import time
 from random import getrandbits
+import sys
+from time import time
+
+PY3 = sys.version_info[0] == 3
 
 try:
     import urllib.parse as urllib_parse
     from urllib.parse import urlencode
-    PY3 = True
 except ImportError:
     import urllib2 as urllib_parse
     from urllib import urlencode
-    PY3 = False
 
 import hashlib
 import hmac


### PR DESCRIPTION
oauth.py guesses whether it is running under Python 3 by the existance of urllib.parse.urllib_parse and urllib.parse.urlencode. The code then uses urlencode's safe parameter if it believes it's running under Python 3. Unfortunately the guess fails when using Future, a library for writing clean Python 3 code that is backwards compatible with Python 2, since Future manipulates some builtins.

This change applies the version test that isn't confused by the use of Futures. It's the same test used by the Six library.
