### PR TITLE
Bugfix: queries with retry=True return None when rate-limited

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -351,7 +351,7 @@ class TwitterCall(object):
                     print("Service unavailable; waiting for %ds..." % delay, file=sys.stderr)
                 else:
                     raise
-                if isinstance(retry, int):
+                if isinstance(retry, int) and not isinstance(retry, bool):
                     if retry <= 0:
                         raise
                     retry -= 1


### PR DESCRIPTION
Because bool is a subclass of int, `isinstance(retry, int)` returns True and the
decrement results in retry=0, terminating the while loop. Patches 73a242d.