### PR TITLE
Update oauth_dance.py

### DIFF
--- a/twitter/oauth_dance.py
+++ b/twitter/oauth_dance.py
@@ -25,8 +25,7 @@ def oauth2_dance(consumer_key, consumer_secret, token_filename=None):
         auth=OAuth2(consumer_key=consumer_key, consumer_secret=consumer_secret),
         format="",
         api_version="")
-    token = json.loads(twitter.oauth2.token(grant_type="client_credentials")
-        .encode("utf8"))["access_token"]
+    token = json.loads(twitter.oauth2.token(grant_type="client_credentials"))["access_token"]
     if token_filename:
         write_bearer_token_file(token)
     return token


### PR DESCRIPTION
Fixed bug for python 3.4 in oauth2_dance where response was encoded 
(this works in python 2.7 because json.loads can decode bytes, but in 3.4 json.loads takes only strings!)