### PR TITLE
If json.loads fails, carry on without raising an exception. Fixes #298

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -68,10 +68,14 @@ class TwitterHTTPError(TwitterError):
             data = f.read()
         if len(data) == 0:
             data = {}
-        elif "json" == self.format:
-            data = json.loads(data.decode('utf8'))
         else:
             data = data.decode('utf8')
+            if "json" == self.format:
+                try:
+                    data = json.loads(data)
+                except ValueError:
+                    # We try to load the response as json as a nicety; if it fails, carry on.
+                    pass
         self.response_data = data
         super(TwitterHTTPError, self).__init__(str(self))
 


### PR DESCRIPTION
Here is a possible refactoring to allow the library to carry on if json.loads fails.
(Note: I am not sure how to reproduce the error, so I haven't been able to test this yet. I have tested that posting works.)
Fixes #298