### PR TITLE
Fixes oauth2_dance when a token_filename is passed

### DIFF
--- a/twitter/oauth_dance.py
+++ b/twitter/oauth_dance.py
@@ -27,7 +27,7 @@ def oauth2_dance(consumer_key, consumer_secret, token_filename=None):
         api_version="")
     token = json.loads(twitter.oauth2.token(grant_type="client_credentials"))["access_token"]
     if token_filename:
-        write_bearer_token_file(token)
+        write_bearer_token_file(token_filename, token)
     return token
 
 def oauth_dance(app_name, consumer_key, consumer_secret, token_filename=None):


### PR DESCRIPTION
It looks like `oauth2_dance` doesn't currently pass the
correct number of arguments to `oauth2.write_bearer_token_file`.

This results in a `TypeError`:

```
>>> cons = 'MY_KEY'
>>> sec = 'MY_SECRET'
>>> oauth2_dance(cons, sec, 'bearer.txt')
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/Users/dex/.venv/lib/python2.7/site-packages/twitter/oauth_dance.py", line 30, in oauth2_dance
    write_bearer_token_file(token)
TypeError: write_bearer_token_file() takes exactly 2 arguments (1 given)
```

This change updates `oauth2_dance` to pass both the token and the
filename to `write_bearer_token_file`.