### PR TITLE
Coverage 4.0 doesn't support Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ python:
 - "pypy"
 
 install:
-  - pip install coveralls
+ # Coveralls 4.0 doesn't support Python 3.2
+  - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then pip install coverage==3.7.1; fi
+  - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then pip install coverage; fi
 
 script: nosetests --with-coverage --cover-package=twitter
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ python:
 - "3.5"
 - "pypy"
 
+# Use container-based infrastructure
+sudo: false
+
 install:
  # Coveralls 4.0 doesn't support Python 3.2
   - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then pip install coverage==3.7.1; fi


### PR DESCRIPTION
So use the last one that worked for 3.2. Fixes #310.

Also use container-based infrastructure for quicker builds: https://docs.travis-ci.com/user/workers/container-based-infrastructure/
