### PR TITLE
Fix ResourceWarning on read_bearer_toke_file func

### DIFF
--- a/twitter/oauth2.py
+++ b/twitter/oauth2.py
@@ -46,7 +46,9 @@ def read_bearer_token_file(filename):
     Read a token file and return the oauth2 bearer token.
     """
     f = open(filename)
-    return f.readline().strip()
+    bearer_token = f.readline().strip()
+    f.close()
+    return bearer_token
 
 class OAuth2(Auth):
     """


### PR DESCRIPTION
This should fix the following warning when doing a unit test: ResourceWarning: unclosed file <_io.TextIOWrapper name='bearer_token' mode='r' encoding='cp1252'> -- Python 3.5, unittest