### PR TITLE
Avoid possible negative values of delay in sleep(delay)

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -354,6 +354,8 @@ class TwitterCall(object):
                     # API rate limit reached
                     reset = int(e.e.headers.get('X-Rate-Limit-Reset', time() + 30))
                     delay = int(reset - time() + 2)  # add some extra margin
+                    if delay <= 0:
+                        delay = self.TWITTER_UNAVAILABLE_WAIT
                     print("API rate limit reached; waiting for %ds..." % delay, file=sys.stderr)
                 elif e.e.code in (502, 503, 504):
                     delay = self.TWITTER_UNAVAILABLE_WAIT
@@ -364,8 +366,6 @@ class TwitterCall(object):
                     if retry <= 0:
                         raise
                     retry -= 1
-                if delay <= 0:
-                    delay = self.TWITTER_UNAVAILABLE_WAIT
                 sleep(delay)
 
 

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -364,6 +364,8 @@ class TwitterCall(object):
                     if retry <= 0:
                         raise
                     retry -= 1
+                if delay <= 0:
+                    delay = self.TWITTER_UNAVAILABLE_WAIT
                 sleep(delay)
 
 


### PR DESCRIPTION
Found this problem using ```twitter.retry = True``` in a multiple query that exceeded current window. I don't know why **delay** can be negative (maybe **time()** and **reset** not in sync, somehow?) but this validation seems to be a defensive strategy not too expensive.