### PR TITLE
Naming/ordering of keys/secrets in examples (in readme & api.py) is off

### DIFF
--- a/README
+++ b/README
@@ -83,7 +83,7 @@ Examples:
 from twitter import *
 
 t = Twitter(
-    auth=OAuth(token, token_key, con_secret_key, con_secret))
+    auth=OAuth(token, token_secret, consumer_key, consumer_secret))
 
 # Get your "home" timeline
 t.statuses.home_timeline()
@@ -128,7 +128,7 @@ with open("example.png", "rb") as imagefile:
 # - then upload medias one by one on Twitter's dedicated server
 #   and collect each one's id:
 t_upload = Twitter(domain='upload.twitter.com',
-    auth=OAuth(token, token_key, con_secret_key, con_secret))
+    auth=OAuth(token, token_secret, consumer_key, consumer_secret))
 id_img1 = t_upload.media.upload(media=imagedata)["media_id_string"]
 id_img2 = t_upload.media.upload(media=imagedata)["media_id_string"]
 # - finally send your tweet with the list of media ids:

--- a/README
+++ b/README
@@ -83,7 +83,7 @@ Examples:
 from twitter import *
 
 t = Twitter(
-    auth=OAuth(token, token_key, con_secret, con_secret_key))
+    auth=OAuth(token, token_key, con_secret_key, con_secret))
 
 # Get your "home" timeline
 t.statuses.home_timeline()
@@ -128,7 +128,7 @@ with open("example.png", "rb") as imagefile:
 # - then upload medias one by one on Twitter's dedicated server
 #   and collect each one's id:
 t_upload = Twitter(domain='upload.twitter.com',
-    auth=OAuth(token, token_key, con_secret, con_secret_key))
+    auth=OAuth(token, token_key, con_secret_key, con_secret))
 id_img1 = t_upload.media.upload(media=imagedata)["media_id_string"]
 id_img2 = t_upload.media.upload(media=imagedata)["media_id_string"]
 # - finally send your tweet with the list of media ids:

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -400,7 +400,7 @@ class Twitter(TwitterCall):
         from twitter import *
 
         t = Twitter(
-            auth=OAuth(token, token_key, con_secret, con_secret_key))
+            auth=OAuth(token, token_secret, consumer_key, consumer_secret))
 
         # Get your "home" timeline
         t.statuses.home_timeline()
@@ -446,7 +446,7 @@ class Twitter(TwitterCall):
         # - then upload medias one by one on Twitter's dedicated server
         #   and collect each one's id:
         t_upload = Twitter(domain='upload.twitter.com',
-            auth=OAuth(token, token_key, con_secret, con_secret_key))
+            auth=OAuth(token, token_secret, consumer_key, consumer_secret))
         id_img1 = t_upload.media.upload(media=imagedata)["media_id_string"]
         id_img2 = t_upload.media.upload(media=imagedata)["media_id_string"]
 


### PR DESCRIPTION
It took me a bit longer than it should have to use this library today because the basic example code (in the readme & as generated from api.py) has the consumer secret & consumer key in the wrong order. 

This is a pull request to change that order in the docs, and to rename the example vars to match the ones in the oauth examples further down in the documentation. 

Thanks!