### PR TITLE
Add Python 3.6, drop unsupported 2.6, 3.2, 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,17 @@
 language: python
 
 python:
-- "2.6"
 - "2.7"
-- "3.2"
-- "3.3"
 - "3.4"
 - "3.5"
+- "3.6"
 - "pypy"
 
 # Use container-based infrastructure
 sudo: false
 
 install:
- # Coveralls 4.0 doesn't support Python 3.2
-  - if [ "$TRAVIS_PYTHON_VERSION" == "3.2" ]; then pip install coverage==3.7.1; fi
-  - if [ "$TRAVIS_PYTHON_VERSION" != "3.2" ]; then pip install coverage; fi
+  - pip install coverage
 
 script: nosetests --with-coverage --cover-package=twitter
 

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ version = '1.17.1'
 install_requires = [
     # -*- Extra requirements: -*-
     ]
-if sys.version_info < (2,7):
-    install_requires.append('argparse')
 
 tests_require = [
     'nose',
@@ -30,11 +28,12 @@ setup(name='twitter',
           "Intended Audience :: End Users/Desktop",
           "Natural Language :: English",
           "Operating System :: OS Independent",
-          "Programming Language :: Python :: 2.6",
+          "Programming Language :: Python :: 2",
           "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 3.2",
-          "Programming Language :: Python :: 3.3",
+          "Programming Language :: Python :: 3",
           "Programming Language :: Python :: 3.4",
+          "Programming Language :: Python :: 3.5",
+          "Programming Language :: Python :: 3.6",
           "Topic :: Communications :: Chat :: Internet Relay Chat",
           "Topic :: Internet :: WWW/HTTP :: Dynamic Content :: CGI Tools/Libraries",
           "Topic :: Utilities",


### PR DESCRIPTION
## Reasons for dropping old ones

* https://en.wikipedia.org/wiki/CPython#Version_history

### 2.6

* https://snarky.ca/stop-using-python-2-6/
* http://www.curiousefficiency.org/posts/2015/04/stop-supporting-python26.html
* Current pip 9 deprecates Python 2.6 support, pip 10 won't support it (https://github.com/pypa/pip/issues/3955)

### 3.2

* pip 8 no longer supports Python 3.2 ([link](https://pip.pypa.io/en/stable/news/))
* Coverage 4 no longer supports Python 3.2 ([link](https://bitbucket.org/ned/coveragepy/issues/407/coverage-failing-on-python-325-using))
* Requests no longer supports Python 3.2

### 3.3

* pip 10 will deprecate Python 3.3 support, pip 11 won't support it (https://github.com/pypa/pip/issues/3796)