### PR TITLE
Fix OAuth for new Twitter Labs API routes

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -35,6 +35,16 @@ twitter11_na = Twitter(domain='api.twitter.com',
                        auth=noauth,
                        api_version='1.1')
 
+twitterlabs = Twitter(domain='api.twitter.com',
+                    auth=oauth,
+                    api_version='labs/1',
+                    format='')
+
+twitterlabs_app = Twitter(domain='api.twitter.com',
+                    auth=oauth2,
+                    api_version='labs/1',
+                    format='')
+
 AZaz = "abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 b64_image_data = b"iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB94JFhMBAJv5kaUAAAAZdEVYdENvbW1lbnQAQ3JlYXRlZCB3aXRoIEdJTVBXgQ4XAAAA4UlEQVQoz7WSIZLGIAxG6c5OFZjianBcIOfgPkju1DsEBWfAUEcNGGpY8Xe7dDoVFRvHfO8NJGRorZE39UVe1nd/WNfVObcsi3OOEAIASikAmOf5D2q/FWPUWgshKKWfiFIqhNBaxxhPjPQ05/z+Bs557xw9hBC89ymlu5BS8t6HEC5NW2sR8alRRLTWXoRSSinlSejT12M9BAAAgCeoTw9BSimlfBIu6WdYtVZEVErdaaUUItZaL/9wOsaY83YAMMb0dGtt6Jdv3/ec87ZtOWdCCGNsmibG2DiOJzP8+7b+AAOmsiPxyHWCAAAAAElFTkSuQmCC"
@@ -147,6 +157,14 @@ def test_get_tweet():
 
 def test_get_tweet_app_auth():
     _test_get_tweet(twitter11_app.statuses.lookup(_id='27095053386121216', include_entities="true", tweet_mode="extended"))
+
+
+def test_get_tweet_labs():
+    _test_get_tweet(twitterlabs.tweets(ids='27095053386121216', format='detailed', expansions='attachments.poll_ids,attachments.media_keys,author_id,entities.mentions.username,geo.place_id,in_reply_to_user_id,referenced_tweets.id,referenced_tweets.id.author_id'))
+
+
+def test_get_tweet_labs_app_auth():
+    _test_get_tweet(twitterlabs_app.tweets(ids='27095053386121216', format='detailed', expansions='attachments.poll_ids,attachments.media_keys,author_id,entities.mentions.username,geo.place_id,in_reply_to_user_id,referenced_tweets.id,referenced_tweets.id.author_id'))
 
 
 def test_search():

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -282,11 +282,12 @@ class TwitterCall(object):
             headers['Content-Type'] = 'application/json; charset=UTF-8'
 
         if self.auth:
-            headers.update(self.auth.generate_headers())
+            params = {} if media or jsondata else kwargs
+            headers.update(self.auth.generate_headers(url_base, method, params))
             # Use urlencoded oauth args with no params when sending media
             # via multipart and send it directly via uri even for post
             arg_data = self.auth.encode_params(
-                url_base, method, {} if media or jsondata else kwargs)
+                url_base, method, params)
             if method == 'GET' or media or jsondata:
                 url_base += '?' + arg_data
             else:

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -355,7 +355,7 @@ class TwitterCall(object):
                 data = f.read()
             if len(data) == 0:
                 return wrap_response({}, handle.headers)
-            elif "json" == self.format:
+            elif "json" == self.format or "/labs/" in uri:
                 res = json.loads(data.decode('utf8'))
                 return wrap_response(res, handle.headers)
             else:

--- a/twitter/auth.py
+++ b/twitter/auth.py
@@ -17,7 +17,7 @@ class Auth(object):
         if required by the authentication scheme in use."""
         raise NotImplementedError()
 
-    def generate_headers(self):
+    def generate_headers(self, *args, **kwargs):
         """Generates headers which should be added to the request if required
         by the authentication scheme in use."""
         raise NotImplementedError()
@@ -37,7 +37,7 @@ class UserPassAuth(Auth):
         # before encoding...
         return urllib_parse.urlencode(params)
 
-    def generate_headers(self):
+    def generate_headers(self, *args, **kwargs):
         return {b"Authorization": b"Basic " + encodebytes(
                 ("%s:%s" %(self.username, self.password))
                 .encode('utf8')).strip(b'\n')
@@ -54,7 +54,7 @@ class NoAuth(Auth):
     def encode_params(self, base_url, method, params):
         return urllib_parse.urlencode(params)
 
-    def generate_headers(self):
+    def generate_headers(self, *args, **kwargs):
         return {}
 
 

--- a/twitter/oauth.py
+++ b/twitter/oauth.py
@@ -97,14 +97,15 @@ class OAuth(Auth):
                 'You must supply strings for token_secret and consumer_secret, not None.')
 
     def encode_params(self, base_url, method, params):
+        return urlencode_noplus(sorted(params.items()))
+
+    def generate_headers(self, base_url=None, method=None, params=None):
         params = params.copy()
 
-        if self.token:
-            params['oauth_token'] = self.token
-
-        params['oauth_consumer_key'] = self.consumer_key
-        params['oauth_signature_method'] = 'HMAC-SHA1'
         params['oauth_version'] = '1.0'
+        params['oauth_signature_method'] = 'HMAC-SHA1'
+        params['oauth_consumer_key'] = self.consumer_key
+        params['oauth_token'] = self.token
         params['oauth_timestamp'] = str(int(time()))
         params['oauth_nonce'] = str(getrandbits(64))
 
@@ -115,13 +116,26 @@ class OAuth(Auth):
         message = '&'.join(
             urllib_parse.quote(i, safe='~') for i in [method.upper(), base_url, enc_params])
 
-        signature = (base64.b64encode(hmac.new(
-                    key.encode('ascii'), message.encode('ascii'), hashlib.sha1)
-                                      .digest()))
-        return enc_params + "&" + "oauth_signature=" + urllib_parse.quote(signature, safe='~')
+        signature = urllib_parse.quote(
+            base64.b64encode(
+                hmac.new(
+                    key.encode('ascii'),
+                    message.encode('ascii'),
+                    hashlib.sha1
+                ).digest()
+            ), safe='~'
+        )
 
-    def generate_headers(self):
-        return {}
+        return {
+            b'Authorization': ('''OAuth oauth_version="1.0",
+                oauth_signature_method="HMAC-SHA1",
+                oauth_consumer_key="%s",
+                oauth_token="%s",
+                oauth_timestamp="%s",
+                oauth_nonce="%s",
+                oauth_signature="%s"''' % (self.consumer_key, self.token, params["oauth_timestamp"], params["oauth_nonce"], signature)).encode("utf-8")
+        }
+
 
 # apparently contrary to the HTTP RFCs, spaces in arguments must be encoded as
 # %20 rather than '+' when constructing an OAuth signature (and therefore

--- a/twitter/oauth2.py
+++ b/twitter/oauth2.py
@@ -73,7 +73,7 @@ class OAuth2(Auth):
     def encode_params(self, base_url, method, params):
         return urlencode(params)
 
-    def generate_headers(self):
+    def generate_headers(self, *args, **kwargs):
         if self.bearer_token:
             headers = {
                 b'Authorization': 'Bearer {0}'.format(


### PR DESCRIPTION
This PR changes the way OAuth calls are performed: they were previously done by passing OAuth args into the query's params, whereas the spec authorizes this but [strongly recommends](https://oauth.net/core/1.0a/#consumer_req_param) to rather use the query's headers.
This was not an issue so far, but the [new Labs routes](https://developer.twitter.com/en/docs/labs/overview/introduction) currently being beta developed by Twitter [do not support this anymore](https://twittercommunity.com/t/problem-with-oauth-1-0a-on-labs-new-routes/127382).

New labs routes can now be called for instance as such:
```
twitterlabs = Twitter(domain='api.twitter.com', auth=oauth, api_version='labs/1', format='')
twitterlabs.tweets(ids='TWEET1_ID,TWEET2_ID,...', format='detailed')
```

This also raises questions towards the `format` parameter becoming troublesome, cf description of https://github.com/sixohsix/twitter/commit/327475faccf0cd7dc30f43a977922609d09c10bb

And last but not least, using the Labs routes require the developer to enable them from the Developer section of Twitter's website. Because of this, the tests added specifically for these routes are breaking for now. @sixohsix could you enable it for the account used in the tests by travis? This can be done here: https://developer.twitter.com/en/labs-apply

And a new release would probably be welcome once the tests are valid and the PR merged :)