### PR TITLE
Replace unmaintained nose with pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ python:
 - "pypy"
 
 install:
-  - pip install coverage
+  - pip install pytest pytest-cov
 
-script: nosetests --with-coverage --cover-package=twitter
+script: pytest --cov twitter --cov tests
 
 after_success:
   - pip install coveralls && coveralls

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,6 @@ except ImportError:
 
 version = '1.18.0'
 
-tests_require = [
-    'nose',
-    ]
-
 setup(name='twitter',
       version=version,
       description="An API and command-line toolset for Twitter (twitter.com)",
@@ -47,8 +43,6 @@ setup(name='twitter',
       packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
       include_package_data=True,
       zip_safe=True,
-      tests_require=tests_require,
-      test_suite = 'nose.collector',
       entry_points="""
       # -*- Entry points: -*-
       [console_scripts]


### PR DESCRIPTION
Fixes #405.

The `nightly` (Python 3.9) is failing because Nose doesn't support it and is no longer maintained: https://github.com/nose-devs/nose/issues/1099.

> Nose has been in maintenance mode for the past several years and will likely cease without a new person/team to take over maintainership. New projects should consider using Nose2, py.test, or just plain unittest/unittest2.

https://nose.readthedocs.io/en/latest/

> nose2 may or may not be a good fit for your project.
>
> If you are new to python testing, we encourage you to also consider pytest, a popular testing framework.

https://docs.nose2.io/en/latest/

I also recommend pytest.
