### PR TITLE
Fix for broken PUT methods #414

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -285,8 +285,12 @@ class TwitterCall(object):
             headers.update(self.auth.generate_headers())
             # Use urlencoded oauth args with no params when sending media
             # via multipart and send it directly via uri even for post
+            url_args = {} if media or jsondata else kwargs
+            if method == "PUT" and _id:
+                # the two PUT method APIs both require uri id parameter
+                url_args['id'] = _id
             arg_data = self.auth.encode_params(
-                url_base, method, {} if media or jsondata else kwargs)
+                url_base, method, url_args)
             if method == 'GET' or media or jsondata:
                 url_base += '?' + arg_data
             else:
@@ -327,7 +331,7 @@ class TwitterCall(object):
                 for k in headers:
                     headers[actually_bytes(k)] = actually_bytes(headers.pop(k))
 
-        req = urllib_request.Request(url_base, data=body, headers=headers)
+        req = urllib_request.Request(url_base, data=body, headers=headers, method=method)
         if self.retry:
             return self._handle_response_with_retry(req, uri, arg_data, _timeout)
         else:

--- a/twitter/api.py
+++ b/twitter/api.py
@@ -331,7 +331,14 @@ class TwitterCall(object):
                 for k in headers:
                     headers[actually_bytes(k)] = actually_bytes(headers.pop(k))
 
-        req = urllib_request.Request(url_base, data=body, headers=headers, method=method)
+        req = urllib_request.Request(url_base, data=body, headers=headers)
+        # Horrible hack, the python2/urllib2 version of request doesn't
+        # take a method parameter, but we can overwrite the class
+        # get_method() function to a lambda function that always returns
+        # the method we want...
+        # https://stackoverflow.com/questions/111945/is-there-any-way-to-do-http-put-in-python/111988#111988
+        req.get_method = lambda: method
+
         if self.retry:
             return self._handle_response_with_retry(req, uri, arg_data, _timeout)
         else:


### PR DESCRIPTION
Pass _method directly to urllib_request to enable PUT requests and also ensure consistency between signature and actual request,.

Pass id parameter into auth.encode_params() for PUT requests, as required by two existing API methods using PUT.