### PR TITLE
Fix CI: Upgrade pytest and pytest-cov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 
 python:
 - "2.7"
@@ -12,7 +13,7 @@ python:
 - "pypy"
 
 install:
-  - pip install pytest pytest-cov
+  - pip install -U pytest pytest-cov
 
 script: pytest --cov twitter --cov tests
 


### PR DESCRIPTION
To fix the CI, which was failing on master (eg. https://travis-ci.org/github/hugovk/twitter/builds/703458586).

Also cache pip downloads to speed things up a bit.