### PR TITLE
docs: fix simple typo, similarily -> similarly

### DIFF
--- a/twitter/api.py
+++ b/twitter/api.py
@@ -478,7 +478,7 @@ class Twitter(TwitterCall):
         # - finally send your tweet with the list of media ids:
         t.statuses.update(status="PTT ★", media_ids=",".join([id_img1, id_img2]))
 
-        # Or send a tweet with an image (or set a logo/banner similarily)
+        # Or send a tweet with an image (or set a logo/banner similarly)
         # using the old deprecated method that will probably disappear some day
         params = {"media[]": imagedata, "status": "PTT ★"}
         # Or for an image encoded as base64:


### PR DESCRIPTION
There is a small typo in README.md, twitter/api.py.

Should read `similarly` rather than `similarily`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md