### PR TITLE
Fixing an issue related to pickling

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -165,6 +165,10 @@ def test_picklability():
     assert res == res2
     assert res2[2] == 3
 
+    p = pickle.dumps(twitter11)
+    s = pickle.loads(p)
+    assert twitter11.domain == s.domain
+
 
 def test_jsonifability():
     res = TwitterDictResponse({'a': 'b'})


### PR DESCRIPTION
This PR fixes the client's `__getattr` method which was erroneously calling Twitter's API when attempting to pickle. I have dropped the `object.__getattr__` part because this attribute does not exist on `object` and was therefore useless.